### PR TITLE
id_token["aud"] may be a single item list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,9 @@ provider.
 
 It has been tested with:
 
--  `Google+ Login`_
--  `Ipsilon`_
+* `Google+ Login <https://developers.google.com/accounts/docs/OAuth2Login>`_
+* `Ipsilon <https://ipsilon-project.org/>`_
+* `MojeID <https://mojeid.cz>`_
 
 --------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,7 +72,7 @@ A very basic example client::
     def index():
         if oidc.user_loggedin:
             return 'Welcome %s' % oidc.user_getfield('email')
-        else
+        else:
             return 'Not logged in'
 
     @app.route('/login')
@@ -136,6 +136,7 @@ for information on how to obtain client secrets.
 For example, for Google, you will need to visit `Google API credentials management
 <https://console.developers.google.com/apis/credentials?project=_>`_.
 
+For `MojeID <https://www.mojeid.cz/en/provider/getting-started/>`_, you type ``oidc-register https://mojeid.cz/oidc/ https://your-application``.
 
 Manual client registration
 --------------------------

--- a/flask_oidc_ext/__init__.py
+++ b/flask_oidc_ext/__init__.py
@@ -646,7 +646,9 @@ class OpenIDConnect(object):
             logger.error("id_token issued by non-trusted issuer: %s" % id_token["iss"])
             return False
 
-        if isinstance(id_token["aud"], list):
+        if isinstance(id_token['aud'], list) and len(id_token['aud']) == 1:
+            id_token['aud'] = id_token['aud'][0]
+        if isinstance(id_token['aud'], list):
             # step 3 for audience list
             if self.flow.client_id not in id_token["aud"]:
                 logger.error("We are not a valid audience")


### PR DESCRIPTION
MojeID provider returns 'aud': ['single-id'] which was by mistake taken as multiple audiences without 'azp'.
Added MojeID as a tested provider.