### PR TITLE
Handle error: NameError: name 'SignatureExpired' is not defined

### DIFF
--- a/flask_oidc_ext/__init__.py
+++ b/flask_oidc_ext/__init__.py
@@ -42,7 +42,7 @@ from oauth2client.client import (
     OAuth2Credentials,
 )
 import httplib2
-from itsdangerous import JSONWebSignatureSerializer, BadSignature
+from itsdangerous import JSONWebSignatureSerializer, BadSignature, SignatureExpired
 
 __all__ = ["OpenIDConnect", "MemoryCredentials"]
 

--- a/flask_oidc_ext/__init__.py
+++ b/flask_oidc_ext/__init__.py
@@ -599,7 +599,7 @@ class OpenIDConnect(object):
            Use :func:`require_login` instead.
         """
         if not self._custom_callback and customstate:
-            raise ValueError("Custom State is only avilable with a custom " "handler")
+            raise ValueError("Custom State is only avilable with a custom handler")
         if "oidc_csrf_token" not in session:
             csrf_token = urlsafe_b64encode(os.urandom(24)).decode("utf-8")
             session["oidc_csrf_token"] = csrf_token
@@ -861,7 +861,7 @@ class OpenIDConnect(object):
                     valid_audience = clid == aud
 
                 if not valid_audience:
-                    logger.error("Refused token because of invalid " "audience")
+                    logger.error("Refused token because of invalid audience")
                     valid_token = False
 
             if valid_token:


### PR DESCRIPTION
Error handling appears to fail during invalid cookie due to missing import.

I have itsdangerous 1.1.0 installed in pip3 but still get the error.  Fixing the import should solve that.

Received this error:
```
NameError
NameError: name 'SignatureExpired' is not defined

Traceback (most recent call last)
File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/flask_oidc_ext/__init__.py", line 375, in _get_cookie_id_token
return self.cookie_serializer.loads(id_token_cookie)
File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/itsdangerous/jws.py", line 143, in loads
self.make_signer(salt, self.algorithm).unsign(want_bytes(s)),
File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/itsdangerous/signer.py", line 169, in unsign
raise BadSignature("Signature %r does not match" % sig, payload=value)
During handling of the above exception, another exception occurred:
File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/flask/app.py", line 1948, in full_dispatch_request
rv = self.preprocess_request()
File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/flask/app.py", line 2242, in preprocess_request
rv = func()
File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/flask_oidc_ext/__init__.py", line 437, in _before_request
self.authenticate_or_redirect()
File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/flask_oidc_ext/__init__.py", line 457, in authenticate_or_redirect
id_token = self._get_cookie_id_token()
File "/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages/flask_oidc_ext/__init__.py", line 376, in _get_cookie_id_token
except SignatureExpired:
NameError: name 'SignatureExpired' is not defined
The debugger caught an exception in your WSGI application. You can now look at the traceback which led to the error.
To switch between the interactive traceback and the plaintext one, you can click on the "Traceback" headline. From the text traceback you can also create a paste of it.

Brought to you by DON'T PANIC, your friendly Werkzeug powered traceback interpreter.
```

DCO 1.1 Signed-off-by: Andrew R. Freed <afreed@us.ibm.com>